### PR TITLE
feat: disable memory profiling by default

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -36,16 +36,6 @@ func ListenAndServe(ctx context.Context, addr string, log LogFunc) error {
 		return nil
 	}
 
-	// that's defaults, just make them explicit
-	runtime.SetCPUProfileRate(100)
-	runtime.MemProfileRate = 512 * 1024
-
-	// https://github.com/DataDog/go-profiler-notes/blob/main/block.md#overhead
-	runtime.SetBlockProfileRate(10000)
-
-	// no science behind that value
-	runtime.SetMutexProfileFraction(10000)
-
 	log("starting debug server")
 
 	for _, h := range handlers() {
@@ -84,4 +74,23 @@ func handlers() []string {
 	sort.Strings(res)
 
 	return res
+}
+
+func init() {
+	if !Enabled {
+		// explicitly disable memory profiling to save around 1.4MiB of memory
+		runtime.MemProfileRate = 0
+
+		return
+	}
+
+	// that's defaults, just make them explicit
+	runtime.SetCPUProfileRate(100)
+	runtime.MemProfileRate = 512 * 1024
+
+	// https://github.com/DataDog/go-profiler-notes/blob/main/block.md#overhead
+	runtime.SetBlockProfileRate(10000)
+
+	// no science behind that value
+	runtime.SetMutexProfileFraction(10000)
 }

--- a/debug_off.go
+++ b/debug_off.go
@@ -7,4 +7,6 @@
 package debug
 
 // Enabled is false when compiled without sidero.debug build tag.
+//
+// Profiling is disabled to safe resources as a side-effect of importing this package.
 const Enabled = false

--- a/debug_off_test.go
+++ b/debug_off_test.go
@@ -7,6 +7,7 @@
 package debug //nolint:testpackage // to test unexported method
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,4 +16,6 @@ import (
 func TestDebugOff(t *testing.T) {
 	expected := []string{}
 	assert.Equal(t, expected, handlers())
+
+	assert.Equal(t, 0, runtime.MemProfileRate)
 }

--- a/debug_on.go
+++ b/debug_on.go
@@ -16,4 +16,6 @@ import (
 )
 
 // Enabled is true when compiled with sidero.debug build tag.
+//
+// Profiling rates are configured as a side-effect of importing this package.
 const Enabled = true

--- a/debug_on_test.go
+++ b/debug_on_test.go
@@ -7,6 +7,7 @@
 package debug //nolint:testpackage // to test unexported method
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,4 +25,6 @@ func TestDebugOn(t *testing.T) {
 		"/debug/vars",
 	}
 	assert.Equal(t, expected, handlers())
+
+	assert.Equal(t, 524288, runtime.MemProfileRate)
 }


### PR DESCRIPTION
To save resources.

https://github.com/talos-systems/talos/blob/c9651673b9eaf811ae4acfed313debbf78bd80e8/internal/app/init/main.go#L27-L30