### PR TITLE
feat: race build tag flag detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@
 
 `go-debug` is a Sidero-specific library for including debugging facilities for developers in our products when they are compiled with `sidero.debug` build tag.
 They are not included by default.
+Also provides utils for detecting if the code was compiled with `race` build tag.

--- a/debug.go
+++ b/debug.go
@@ -4,6 +4,7 @@
 
 // Package debug is a Sidero-specific library for including debugging facilities for developers in our products
 // when they are compiled with sidero.debug build tag. They are not included by default.
+// Also provides utils for detecting if the code was compiled with race build tag.
 package debug
 
 import (

--- a/race_off.go
+++ b/race_off.go
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// +build !race
+
+package debug
+
+// RaceEnabled is false when compiled without race build tag.
+const RaceEnabled = false

--- a/race_on.go
+++ b/race_on.go
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// +build race
+
+package debug
+
+// RaceEnabled is true when compiled with race build tag.
+const RaceEnabled = true


### PR DESCRIPTION
`RaceEnabled` is populated depending on the provided build tags.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>