### PR TITLE
chore: run rekres (update to Go 1.22)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,12 +1,14 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2023-07-10T16:20:59Z by kres latest.
+# Generated on 2024-02-08T22:38:02Z by kres latest.
 
 *
 !debug.go
 !debug_off.go
 !debug_off_test.go
 !debug_on.go
+!debug_on_121.go
+!debug_on_122.go
 !debug_on_test.go
 !race_off.go
 !race_on.go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2023-07-10T16:20:59Z by kres latest.
+# Generated on 2024-02-08T22:37:12Z by kres latest.
 
 # options for analysis running
 run:
@@ -74,6 +74,8 @@ linters-settings:
   govet:
     check-shadowing: true
     enable-all: true
+    disable:
+      - loopclosure
   lll:
     line-length: 200
     tab-width: 4
@@ -148,6 +150,10 @@ linters:
     - wrapcheck
     - depguard # Disabled because starting with golangci-lint 1.53.0 it doesn't allow denylist alone anymore
     - tagalign
+    - inamedparam
+    - testifylint # complains about our assert recorder and has a number of false positives for assert.Greater(t, thing, 1)
+    - protogetter # complains about us using Value field on typed spec, instead of GetValue which has a different signature
+    - perfsprint # complains about us using fmt.Sprintf in non-performance critical code, updating just kres took too long
     # abandoned linters for which golangci shows the warning that the repo is archived by the owner
     - interfacer
     - maligned

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-# syntax = docker/dockerfile-upstream:1.5.2-labs
+# syntax = docker/dockerfile-upstream:1.6.0-labs
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2023-07-10T16:20:59Z by kres latest.
+# Generated on 2024-02-08T22:38:02Z by kres latest.
 
 ARG TOOLCHAIN
 
@@ -10,9 +10,9 @@ ARG TOOLCHAIN
 FROM scratch AS generate
 
 # runs markdownlint
-FROM docker.io/node:20.3.1-alpine3.18 AS lint-markdown
+FROM docker.io/node:21.6.1-alpine3.19 AS lint-markdown
 WORKDIR /src
-RUN npm i -g markdownlint-cli@0.34.0
+RUN npm i -g markdownlint-cli@0.39.0
 RUN npm i sentences-per-line@0.2.1
 COPY .markdownlint.json .
 COPY ./README.md ./README.md
@@ -27,6 +27,10 @@ FROM --platform=${BUILDPLATFORM} toolchain AS tools
 ENV GO111MODULE on
 ARG CGO_ENABLED
 ENV CGO_ENABLED ${CGO_ENABLED}
+ARG GOTOOLCHAIN
+ENV GOTOOLCHAIN ${GOTOOLCHAIN}
+ARG GOEXPERIMENT
+ENV GOEXPERIMENT ${GOEXPERIMENT}
 ENV GOPATH /go
 ARG DEEPCOPY_VERSION
 RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg go install github.com/siderolabs/deep-copy@${DEEPCOPY_VERSION} \
@@ -55,6 +59,8 @@ COPY ./debug.go ./debug.go
 COPY ./debug_off.go ./debug_off.go
 COPY ./debug_off_test.go ./debug_off_test.go
 COPY ./debug_on.go ./debug_on.go
+COPY ./debug_on_121.go ./debug_on_121.go
+COPY ./debug_on_122.go ./debug_on_122.go
 COPY ./debug_on_test.go ./debug_on_test.go
 COPY ./race_off.go ./race_off.go
 COPY ./race_on.go ./race_on.go

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2023-07-10T16:20:59Z by kres latest.
+# Generated on 2024-02-08T22:37:12Z by kres latest.
 
 # common variables
 
@@ -14,18 +14,19 @@ WITH_RACE ?= false
 REGISTRY ?= ghcr.io
 USERNAME ?= siderolabs
 REGISTRY_AND_USERNAME ?= $(REGISTRY)/$(USERNAME)
-PROTOBUF_GO_VERSION ?= 1.28.1
+PROTOBUF_GO_VERSION ?= 1.32.0
 GRPC_GO_VERSION ?= 1.3.0
-GRPC_GATEWAY_VERSION ?= 2.16.0
-VTPROTOBUF_VERSION ?= 0.4.0
+GRPC_GATEWAY_VERSION ?= 2.19.1
+VTPROTOBUF_VERSION ?= 0.6.0
 DEEPCOPY_VERSION ?= v0.5.5
-GOLANGCILINT_VERSION ?= v1.53.3
-GOFUMPT_VERSION ?= v0.5.0
-GO_VERSION ?= 1.20
-GOIMPORTS_VERSION ?= v0.11.0
+GOLANGCILINT_VERSION ?= v1.56.0
+GOFUMPT_VERSION ?= v0.6.0
+GO_VERSION ?= 1.22.0
+GOIMPORTS_VERSION ?= v0.17.0
 GO_BUILDFLAGS ?=
 GO_LDFLAGS ?=
 CGO_ENABLED ?= 0
+GOTOOLCHAIN ?= local
 TESTPKGS ?= ./...
 KRES_IMAGE ?= ghcr.io/siderolabs/kres:latest
 CONFORMANCE_IMAGE ?= ghcr.io/siderolabs/conform:latest
@@ -38,6 +39,7 @@ PROGRESS ?= auto
 PUSH ?= false
 CI_ARGS ?=
 COMMON_ARGS = --file=Dockerfile
+COMMON_ARGS += --provenance=false
 COMMON_ARGS += --progress=$(PROGRESS)
 COMMON_ARGS += --platform=$(PLATFORM)
 COMMON_ARGS += --push=$(PUSH)
@@ -51,6 +53,8 @@ COMMON_ARGS += --build-arg=TOOLCHAIN="$(TOOLCHAIN)"
 COMMON_ARGS += --build-arg=CGO_ENABLED="$(CGO_ENABLED)"
 COMMON_ARGS += --build-arg=GO_BUILDFLAGS="$(GO_BUILDFLAGS)"
 COMMON_ARGS += --build-arg=GO_LDFLAGS="$(GO_LDFLAGS)"
+COMMON_ARGS += --build-arg=GOTOOLCHAIN="$(GOTOOLCHAIN)"
+COMMON_ARGS += --build-arg=GOEXPERIMENT="$(GOEXPERIMENT)"
 COMMON_ARGS += --build-arg=PROTOBUF_GO_VERSION="$(PROTOBUF_GO_VERSION)"
 COMMON_ARGS += --build-arg=GRPC_GO_VERSION="$(GRPC_GO_VERSION)"
 COMMON_ARGS += --build-arg=GRPC_GATEWAY_VERSION="$(GRPC_GATEWAY_VERSION)"
@@ -60,7 +64,7 @@ COMMON_ARGS += --build-arg=GOLANGCILINT_VERSION="$(GOLANGCILINT_VERSION)"
 COMMON_ARGS += --build-arg=GOIMPORTS_VERSION="$(GOIMPORTS_VERSION)"
 COMMON_ARGS += --build-arg=GOFUMPT_VERSION="$(GOFUMPT_VERSION)"
 COMMON_ARGS += --build-arg=TESTPKGS="$(TESTPKGS)"
-TOOLCHAIN ?= docker.io/golang:1.20-alpine
+TOOLCHAIN ?= docker.io/golang:1.22-alpine
 
 # help menu
 
@@ -83,6 +87,23 @@ To create a builder instance, run:
 
 	docker buildx create --name local --use
 
+If running builds that needs to be cached aggresively create a builder instance with the following:
+
+	docker buildx create --name local --use --config=config.toml
+
+config.toml contents:
+
+[worker.oci]
+  gc = true
+  gckeepstorage = 50000
+
+  [[worker.oci.gcpolicy]]
+    keepBytes = 10737418240
+    keepDuration = 604800
+    filters = [ "type==source.local", "type==exec.cachemount", "type==source.git.checkout"]
+  [[worker.oci.gcpolicy]]
+    all = true
+    keepBytes = 53687091200
 
 If you already have a compatible builder instance, you may use that instead.
 
@@ -128,7 +149,8 @@ lint-gofumpt:  ## Runs gofumpt linter.
 .PHONY: fmt
 fmt:  ## Formats the source code
 	@docker run --rm -it -v $(PWD):/src -w /src golang:$(GO_VERSION) \
-		bash -c "export GO111MODULE=on; export GOPROXY=https://proxy.golang.org; \
+		bash -c "export GOTOOLCHAIN=local; \
+		export GO111MODULE=on; export GOPROXY=https://proxy.golang.org; \
 		go install mvdan.cc/gofumpt@$(GOFUMPT_VERSION) && \
 		gofumpt -w ."
 
@@ -164,7 +186,7 @@ lint: lint-golangci-lint lint-gofumpt lint-govulncheck lint-goimports lint-markd
 .PHONY: rekres
 rekres:
 	@docker pull $(KRES_IMAGE)
-	@docker run --rm -v $(PWD):/src -w /src -e GITHUB_TOKEN $(KRES_IMAGE)
+	@docker run --rm --net=host --user $(shell id -u):$(shell id -g) -v $(PWD):/src -w /src -e GITHUB_TOKEN $(KRES_IMAGE)
 
 .PHONY: help
 help:  ## This help menu.

--- a/debug.go
+++ b/debug.go
@@ -13,9 +13,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"reflect"
 	"runtime"
-	"sort"
 )
 
 // LogFunc is a simplest logging function.
@@ -61,21 +59,6 @@ func ListenAndServe(ctx context.Context, addr string, log LogFunc) error {
 	}
 
 	return err
-}
-
-// handlers returns all patterns registered on the default HTTP server mux.
-// Useful to check for unexpected handlers.
-func handlers() []string {
-	keys := reflect.ValueOf(http.DefaultServeMux).Elem().FieldByName("m").MapKeys()
-
-	res := make([]string, len(keys))
-	for i, v := range keys {
-		res[i] = v.String()
-	}
-
-	sort.Strings(res)
-
-	return res
 }
 
 func pprofEnabled() bool {

--- a/debug_on_121.go
+++ b/debug_on_121.go
@@ -1,0 +1,28 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+//go:build !go1.22
+
+package debug
+
+import (
+	"net/http"
+	"reflect"
+	"slices"
+)
+
+// handlers returns all patterns registered on the default HTTP server mux.
+// Useful to check for unexpected handlers.
+func handlers() []string {
+	keys := reflect.ValueOf(http.DefaultServeMux).Elem().FieldByName("m").MapKeys()
+
+	res := make([]string, len(keys))
+	for i, v := range keys {
+		res[i] = v.String()
+	}
+
+	slices.Sort(res)
+
+	return res
+}

--- a/debug_on_122.go
+++ b/debug_on_122.go
@@ -1,0 +1,31 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+//go:build go1.22 && !go1.23
+
+package debug
+
+import (
+	"net/http"
+	"reflect"
+	"slices"
+)
+
+// handlers returns all patterns registered on the default HTTP server mux.
+// Useful to check for unexpected handlers.
+func handlers() []string {
+	// This will only work for Go 1.22, since `http.ServeMux.patterns` contains "remove if possible" comment string
+	// from Go developers.
+	patterns := reflect.ValueOf(http.DefaultServeMux).Elem().FieldByName("patterns")
+	pLen := patterns.Len()
+
+	res := make([]string, pLen)
+	for i := 0; i < pLen; i++ {
+		res[i] = patterns.Index(i).Elem().FieldByName("str").String()
+	}
+
+	slices.Sort(res)
+
+	return res
+}

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/siderolabs/go-debug
 
-go 1.20
+go 1.22.0
 
 require (
 	github.com/stretchr/testify v1.8.4
-	golang.org/x/net v0.12.0
+	golang.org/x/net v0.21.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-golang.org/x/net v0.12.0 h1:cfawfvKITfUsFCeJIHJrbSxpeu/E81khclypR0GVT50=
-golang.org/x/net v0.12.0/go.mod h1:zEVYFnQC7m/vmpQFELhcD1EWkZlX69l4oqgmer6hfKA=
+golang.org/x/net v0.21.0 h1:AQyQV4dYCvJ7vGmJyKki9+PBdyvhkSd8EIx/qb0AYv4=
+golang.org/x/net v0.21.0/go.mod h1:bIjVDfnllIU7BJ2DNgfnXvpSvtn8VRwhlsaeUTyUS44=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
Update `handlers` function to match new `http.ServeMux` internals.