### PR TITLE
chore: add support for Go 1.25

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-08-14T19:08:18Z by kres 7be2a05.
+# Generated on 2025-08-19T12:07:57Z by kres d1ef768.
 
 policies:
   - type: commit

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,9 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-02-13T20:16:28Z by kres 2b55dd5.
+# Generated on 2025-08-19T12:05:47Z by kres d1ef768.
 
 *
+!internal
 !debug.go
 !debug_off.go
 !debug_off_test.go
@@ -13,6 +14,7 @@
 !debug_on_123_test.go
 !debug_on_124.go
 !debug_on_124_test.go
+!debug_on_125_test.go
 !race_off.go
 !race_on.go
 !go.mod
@@ -20,3 +22,4 @@
 !.golangci.yml
 !README.md
 !.markdownlint.json
+!hack/govulncheck.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,7 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-02-13T20:16:28Z by kres 2b55dd5.
+# Generated on 2025-08-19T10:19:30Z by kres ff3b493.
 
-name: default
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -17,6 +16,7 @@ concurrency:
     branches:
       - main
       - release-*
+name: default
 jobs:
   default:
     permissions:
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: gather-system-info
         id: system-info
-        uses: kenchan0130/actions-system-info@v1.3.0
+        uses: kenchan0130/actions-system-info@v1.4.0
         continue-on-error: true
       - name: print-system-info
         run: |
@@ -56,7 +56,7 @@ jobs:
           done
         continue-on-error: true
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Unshallow
         run: |
           git fetch --prune --unshallow

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,21 @@
+# THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
+#
+# Generated on 2025-08-19T10:19:30Z by kres ff3b493.
+
+"on":
+  schedule:
+    - cron: 0 2 * * *
+name: Lock old issues
+permissions:
+  issues: write
+jobs:
+  action:
+    runs-on:
+      - ubuntu-latest
+    steps:
+      - name: Lock old issues
+        uses: dessant/lock-threads@v5.0.1
+        with:
+          issue-inactive-days: "60"
+          log-output: "true"
+          process-only: issues

--- a/.github/workflows/slack-notify-ci-failure.yaml
+++ b/.github/workflows/slack-notify-ci-failure.yaml
@@ -8,28 +8,23 @@
       - default
     types:
       - completed
-name: slack-notify
+    branches:
+      - main
+name: slack-notify-failure
 jobs:
   slack-notify:
     runs-on:
       - self-hosted
       - generic
-    if: github.event.workflow_run.conclusion != 'skipped'
+    if: github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.event != 'pull_request'
     steps:
-      - name: Get PR number
-        id: get-pr-number
-        if: github.event.workflow_run.event == 'pull_request'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          echo pull_request_number=$(gh pr view -R ${{ github.repository }} ${{ github.event.workflow_run.head_repository.owner.login }}:${{ github.event.workflow_run.head_branch }} --json number --jq .number) >> $GITHUB_OUTPUT
       - name: Slack Notify
         uses: slackapi/slack-github-action@v2
         with:
           method: chat.postMessage
           payload: |
             {
-                "channel": "ci-all",
+                "channel": "ci-failure",
                 "text": "${{ github.event.workflow_run.conclusion }} - ${{ github.repository }}",
                 "icon_emoji": "${{ github.event.workflow_run.conclusion == 'success' && ':white_check_mark:' || github.event.workflow_run.conclusion == 'failure' && ':x:' || ':warning:' }}",
                 "username": "GitHub Actions",

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,27 @@
+# THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
+#
+# Generated on 2025-08-19T10:19:30Z by kres ff3b493.
+
+"on":
+  schedule:
+    - cron: 30 1 * * *
+name: Close stale issues and PRs
+permissions:
+  issues: write
+  pull-requests: write
+jobs:
+  stale:
+    runs-on:
+      - ubuntu-latest
+    steps:
+      - name: Close stale issues and PRs
+        uses: actions/stale@v9.1.0
+        with:
+          close-issue-message: This issue was closed because it has been stalled for 7 days with no activity.
+          days-before-issue-close: "5"
+          days-before-issue-stale: "180"
+          days-before-pr-close: "-1"
+          days-before-pr-stale: "45"
+          operations-per-run: "2000"
+          stale-issue-message: This issue is stale because it has been open 180 days with no activity. Remove stale label or comment or this will be closed in 7 days.
+          stale-pr-message: This PR is stale because it has been open 45 days with no activity.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,116 +1,32 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-02-13T20:16:28Z by kres 2b55dd5.
+# Generated on 2025-08-19T10:19:30Z by kres ff3b493.
+
+version: "2"
 
 # options for analysis running
 run:
-  timeout: 10m
+  modules-download-mode: readonly
   issues-exit-code: 1
   tests: true
-  build-tags: [ ]
-  modules-download-mode: readonly
 
 # output configuration options
 output:
   formats:
-    - format: colored-line-number
+    text:
       path: stdout
-  print-issued-lines: true
-  print-linter-name: true
+      print-issued-lines: true
+      print-linter-name: true
   path-prefix: ""
 
-# all available settings of specific linters
-linters-settings:
-  dogsled:
-    max-blank-identifiers: 2
-  dupl:
-    threshold: 150
-  errcheck:
-    check-type-assertions: true
-    check-blank: true
-  exhaustive:
-    default-signifies-exhaustive: false
-  gci:
-    sections:
-      - standard # Standard section: captures all standard packages.
-      - default # Default section: contains all imports that could not be matched to another section type.
-      - localmodule # Imports from the same module.
-  gocognit:
-    min-complexity: 30
-  nestif:
-    min-complexity: 5
-  goconst:
-    min-len: 3
-    min-occurrences: 3
-  gocritic:
-    disabled-checks: [ ]
-  gocyclo:
-    min-complexity: 20
-  godot:
-    scope: declarations
-  gofmt:
-    simplify: true
-  gomodguard: { }
-  govet:
-    enable-all: true
-  lll:
-    line-length: 200
-    tab-width: 4
-  misspell:
-    locale: US
-    ignore-words: [ ]
-  nakedret:
-    max-func-lines: 30
-  prealloc:
-    simple: true
-    range-loops: true # Report preallocation suggestions on range loops, true by default
-    for-loops: false # Report preallocation suggestions on for loops, false by default
-  nolintlint:
-    allow-unused: false
-    allow-no-explanation: [ ]
-    require-explanation: false
-    require-specific: true
-  rowserrcheck: { }
-  testpackage: { }
-  unparam:
-    check-exported: false
-  unused:
-    local-variables-are-used: false
-  whitespace:
-    multi-if: false   # Enforces newlines (or comments) after every multi-line if statement
-    multi-func: false # Enforces newlines (or comments) after every multi-line function signature
-  wsl:
-    strict-append: true
-    allow-assign-and-call: true
-    allow-multiline-assign: true
-    allow-cuddle-declarations: false
-    allow-trailing-comment: false
-    force-case-trailing-whitespace: 0
-    force-err-cuddling: false
-    allow-separated-leading-comment: false
-  gofumpt:
-    extra-rules: false
-  cyclop:
-    # the maximal code complexity to report
-    max-complexity: 20
-  depguard:
-    rules:
-      prevent_unmaintained_packages:
-        list-mode: lax # allow unless explicitly denied
-        files:
-          - $all
-        deny:
-          - pkg: io/ioutil
-            desc: "replaced by io and os packages since Go 1.16: https://tip.golang.org/doc/go1.16#ioutil"
 
 linters:
-  enable-all: true
-  disable-all: false
-  fast: false
+  default: all
   disable:
     - exhaustruct
     - err113
     - forbidigo
+    - funcorder
     - funlen
     - gochecknoglobals
     - gochecknoinits
@@ -131,20 +47,116 @@ linters:
     - testifylint # complains about our assert recorder and has a number of false positives for assert.Greater(t, thing, 1)
     - protogetter # complains about us using Value field on typed spec, instead of GetValue which has a different signature
     - perfsprint # complains about us using fmt.Sprintf in non-performance critical code, updating just kres took too long
-    - goimports # same as gci
     - musttag # seems to be broken - goes into imported libraries and reports issues there
-    - exportloopref # WARN The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar.
+    - nolintlint # gives false positives - disable until https://github.com/golangci/golangci-lint/issues/3228 is resolved
+    - wsl # replaced by wsl_v5
+    - noinlineerr
+    - embeddedstructfieldcheck # fighting in many places with fieldalignment
+  # all available settings of specific linters
+  settings:
+    cyclop:
+      # the maximal code complexity to report
+      max-complexity: 20
+    dogsled:
+      max-blank-identifiers: 2
+    dupl:
+      threshold: 150
+    errcheck:
+      check-type-assertions: true
+      check-blank: true
+    exhaustive:
+      default-signifies-exhaustive: false
+    gocognit:
+      min-complexity: 30
+    nestif:
+      min-complexity: 5
+    goconst:
+      min-len: 3
+      min-occurrences: 3
+    gocritic:
+      disabled-checks: [ ]
+    gocyclo:
+      min-complexity: 20
+    godot:
+      scope: declarations
+    gomodguard: { }
+    govet:
+      enable-all: true
+    lll:
+      line-length: 200
+      tab-width: 4
+    misspell:
+      locale: US
+    nakedret:
+      max-func-lines: 30
+    prealloc:
+      simple: true
+      range-loops: true # Report preallocation suggestions on range loops, true by default
+      for-loops: false # Report preallocation suggestions on for loops, false by default
+    revive:
+      rules:
+        - name: var-naming # Complains about package names like "common"
+          disabled: true
+    rowserrcheck: { }
+    testpackage: { }
+    unparam:
+      check-exported: false
+    unused:
+      local-variables-are-used: false
+    whitespace:
+      multi-if: false   # Enforces newlines (or comments) after every multi-line if statement
+      multi-func: false # Enforces newlines (or comments) after every multi-line function signature
+    wsl:
+      strict-append: true
+      allow-assign-and-call: true
+      allow-multiline-assign: true
+      allow-trailing-comment: false
+      force-case-trailing-whitespace: 0
+      allow-separated-leading-comment: false
+      allow-cuddle-declarations: false
+      force-err-cuddling: false
+    depguard:
+      rules:
+        prevent_unmaintained_packages:
+          list-mode: lax # allow unless explicitly denied
+          files:
+            - $all
+          deny:
+            - pkg: io/ioutil
+              desc: "replaced by io and os packages since Go 1.16: https://tip.golang.org/doc/go1.16#ioutil"
 
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  exclude: [ ]
-  exclude-rules: [ ]
-  exclude-use-default: false
-  exclude-case-sensitive: false
   max-issues-per-linter: 10
   max-same-issues: 3
-  new: false
   uniq-by-line: true
+  new: false
 
 severity:
-  default-severity: error
-  case-sensitive: false
+  default: error
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - localmodule
+    gofmt:
+      simplify: true
+    gofumpt:
+      extra-rules: false
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -2,3 +2,7 @@
 kind: service.CodeCov
 spec:
   targetThreshold: 30
+---
+kind: golang.Generate
+spec:
+  versionPackagePath: internal/version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,22 @@
-# syntax = docker/dockerfile-upstream:1.12.1-labs
+# syntax = docker/dockerfile-upstream:1.17.1-labs
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-02-13T20:16:28Z by kres 2b55dd5.
+# Generated on 2025-08-19T12:07:57Z by kres d1ef768.
 
 ARG TOOLCHAIN
 
-# cleaned up specs and compiled versions
-FROM scratch AS generate
-
 # runs markdownlint
-FROM docker.io/oven/bun:1.1.43-alpine AS lint-markdown
+FROM docker.io/oven/bun:1.2.20-alpine AS lint-markdown
 WORKDIR /src
-RUN bun i markdownlint-cli@0.43.0 sentences-per-line@0.3.0
+RUN bun i markdownlint-cli@0.45.0 sentences-per-line@0.3.0
 COPY .markdownlint.json .
 COPY ./README.md ./README.md
 RUN bunx markdownlint --ignore "CHANGELOG.md" --ignore "**/node_modules/**" --ignore '**/hack/chglog/**' --rules sentences-per-line .
 
 # base toolchain image
 FROM --platform=${BUILDPLATFORM} ${TOOLCHAIN} AS toolchain
-RUN apk --update --no-cache add bash curl build-base protoc protobuf-dev
+RUN apk --update --no-cache add bash build-base curl jq protoc protobuf-dev
 
 # build tools
 FROM --platform=${BUILDPLATFORM} toolchain AS tools
@@ -32,12 +29,12 @@ ARG GOEXPERIMENT
 ENV GOEXPERIMENT=${GOEXPERIMENT}
 ENV GOPATH=/go
 ARG DEEPCOPY_VERSION
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg go install github.com/siderolabs/deep-copy@${DEEPCOPY_VERSION} \
+RUN --mount=type=cache,target=/root/.cache/go-build,id=go-debug/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=go-debug/go/pkg go install github.com/siderolabs/deep-copy@${DEEPCOPY_VERSION} \
 	&& mv /go/bin/deep-copy /bin/deep-copy
 ARG GOLANGCILINT_VERSION
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg go install github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCILINT_VERSION} \
+RUN --mount=type=cache,target=/root/.cache/go-build,id=go-debug/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=go-debug/go/pkg go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANGCILINT_VERSION} \
 	&& mv /go/bin/golangci-lint /bin/golangci-lint
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg go install golang.org/x/vuln/cmd/govulncheck@latest \
+RUN --mount=type=cache,target=/root/.cache/go-build,id=go-debug/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=go-debug/go/pkg go install golang.org/x/vuln/cmd/govulncheck@latest \
 	&& mv /go/bin/govulncheck /bin/govulncheck
 ARG GOFUMPT_VERSION
 RUN go install mvdan.cc/gofumpt@${GOFUMPT_VERSION} \
@@ -49,8 +46,9 @@ WORKDIR /src
 COPY go.mod go.mod
 COPY go.sum go.sum
 RUN cd .
-RUN --mount=type=cache,target=/go/pkg go mod download
-RUN --mount=type=cache,target=/go/pkg go mod verify
+RUN --mount=type=cache,target=/go/pkg,id=go-debug/go/pkg go mod download
+RUN --mount=type=cache,target=/go/pkg,id=go-debug/go/pkg go mod verify
+COPY ./internal ./internal
 COPY ./debug.go ./debug.go
 COPY ./debug_off.go ./debug_off.go
 COPY ./debug_off_test.go ./debug_off_test.go
@@ -61,9 +59,18 @@ COPY ./debug_on_122_test.go ./debug_on_122_test.go
 COPY ./debug_on_123_test.go ./debug_on_123_test.go
 COPY ./debug_on_124.go ./debug_on_124.go
 COPY ./debug_on_124_test.go ./debug_on_124_test.go
+COPY ./debug_on_125_test.go ./debug_on_125_test.go
 COPY ./race_off.go ./race_off.go
 COPY ./race_on.go ./race_on.go
-RUN --mount=type=cache,target=/go/pkg go list -mod=readonly all >/dev/null
+RUN --mount=type=cache,target=/go/pkg,id=go-debug/go/pkg go list -mod=readonly all >/dev/null
+
+FROM tools AS embed-generate
+ARG SHA
+ARG TAG
+WORKDIR /src
+RUN mkdir -p internal/version/data && \
+    echo -n ${SHA} > internal/version/data/sha && \
+    echo -n ${TAG} > internal/version/data/tag
 
 # runs gofumpt
 FROM base AS lint-gofumpt
@@ -74,26 +81,48 @@ FROM base AS lint-golangci-lint
 WORKDIR /src
 COPY .golangci.yml .
 ENV GOGC=50
-RUN golangci-lint config verify --config .golangci.yml
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/root/.cache/golangci-lint --mount=type=cache,target=/go/pkg golangci-lint run --config .golangci.yml
+RUN --mount=type=cache,target=/root/.cache/go-build,id=go-debug/root/.cache/go-build --mount=type=cache,target=/root/.cache/golangci-lint,id=go-debug/root/.cache/golangci-lint,sharing=locked --mount=type=cache,target=/go/pkg,id=go-debug/go/pkg golangci-lint run --config .golangci.yml
+
+# runs golangci-lint fmt
+FROM base AS lint-golangci-lint-fmt-run
+WORKDIR /src
+COPY .golangci.yml .
+ENV GOGC=50
+RUN --mount=type=cache,target=/root/.cache/go-build,id=go-debug/root/.cache/go-build --mount=type=cache,target=/root/.cache/golangci-lint,id=go-debug/root/.cache/golangci-lint,sharing=locked --mount=type=cache,target=/go/pkg,id=go-debug/go/pkg golangci-lint fmt --config .golangci.yml
+RUN --mount=type=cache,target=/root/.cache/go-build,id=go-debug/root/.cache/go-build --mount=type=cache,target=/root/.cache/golangci-lint,id=go-debug/root/.cache/golangci-lint,sharing=locked --mount=type=cache,target=/go/pkg,id=go-debug/go/pkg golangci-lint run --fix --issues-exit-code 0 --config .golangci.yml
 
 # runs govulncheck
 FROM base AS lint-govulncheck
 WORKDIR /src
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg govulncheck ./...
+COPY --chmod=0755 hack/govulncheck.sh ./hack/govulncheck.sh
+RUN --mount=type=cache,target=/root/.cache/go-build,id=go-debug/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=go-debug/go/pkg ./hack/govulncheck.sh ./...
 
 # runs unit-tests with race detector
 FROM base AS unit-tests-race
 WORKDIR /src
 ARG TESTPKGS
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg --mount=type=cache,target=/tmp CGO_ENABLED=1 go test -v -race -count 1 ${TESTPKGS}
+RUN --mount=type=cache,target=/root/.cache/go-build,id=go-debug/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=go-debug/go/pkg --mount=type=cache,target=/tmp,id=go-debug/tmp CGO_ENABLED=1 go test -race ${TESTPKGS}
 
 # runs unit-tests
 FROM base AS unit-tests-run
 WORKDIR /src
 ARG TESTPKGS
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg --mount=type=cache,target=/tmp go test -v -covermode=atomic -coverprofile=coverage.txt -coverpkg=${TESTPKGS} -count 1 ${TESTPKGS}
+RUN --mount=type=cache,target=/root/.cache/go-build,id=go-debug/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=go-debug/go/pkg --mount=type=cache,target=/tmp,id=go-debug/tmp go test -covermode=atomic -coverprofile=coverage.txt -coverpkg=${TESTPKGS} ${TESTPKGS}
+
+FROM embed-generate AS embed-abbrev-generate
+WORKDIR /src
+ARG ABBREV_TAG
+RUN echo -n 'undefined' > internal/version/data/sha && \
+    echo -n ${ABBREV_TAG} > internal/version/data/tag
+
+# clean golangci-lint fmt output
+FROM scratch AS lint-golangci-lint-fmt
+COPY --from=lint-golangci-lint-fmt-run /src .
 
 FROM scratch AS unit-tests
 COPY --from=unit-tests-run /src/coverage.txt /coverage-unit-tests.txt
+
+# cleaned up specs and compiled versions
+FROM scratch AS generate
+COPY --from=embed-abbrev-generate /src/internal/version internal/version
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-02-13T20:16:28Z by kres 2b55dd5.
+# Generated on 2025-08-19T12:07:57Z by kres d1ef768.
 
 # common variables
 
@@ -17,19 +17,21 @@ WITH_RACE ?= false
 REGISTRY ?= ghcr.io
 USERNAME ?= siderolabs
 REGISTRY_AND_USERNAME ?= $(REGISTRY)/$(USERNAME)
-PROTOBUF_GO_VERSION ?= 1.36.2
+PROTOBUF_GO_VERSION ?= 1.36.7
 GRPC_GO_VERSION ?= 1.5.1
-GRPC_GATEWAY_VERSION ?= 2.25.1
+GRPC_GATEWAY_VERSION ?= 2.27.1
 VTPROTOBUF_VERSION ?= 0.6.0
-GOIMPORTS_VERSION ?= 0.29.0
-DEEPCOPY_VERSION ?= v0.5.6
-GOLANGCILINT_VERSION ?= v1.64.4
-GOFUMPT_VERSION ?= v0.7.0
-GO_VERSION ?= 1.24.0
+GOIMPORTS_VERSION ?= 0.36.0
+GOMOCK_VERSION ?= 0.6.0
+DEEPCOPY_VERSION ?= v0.5.8
+GOLANGCILINT_VERSION ?= v2.4.0
+GOFUMPT_VERSION ?= v0.8.0
+GO_VERSION ?= 1.25.0
 GO_BUILDFLAGS ?=
 GO_LDFLAGS ?=
 CGO_ENABLED ?= 0
 GOTOOLCHAIN ?= local
+GOEXPERIMENT ?= synctest
 TESTPKGS ?= ./...
 KRES_IMAGE ?= ghcr.io/siderolabs/kres:latest
 CONFORMANCE_IMAGE ?= ghcr.io/siderolabs/conform:latest
@@ -65,11 +67,12 @@ COMMON_ARGS += --build-arg=GRPC_GO_VERSION="$(GRPC_GO_VERSION)"
 COMMON_ARGS += --build-arg=GRPC_GATEWAY_VERSION="$(GRPC_GATEWAY_VERSION)"
 COMMON_ARGS += --build-arg=VTPROTOBUF_VERSION="$(VTPROTOBUF_VERSION)"
 COMMON_ARGS += --build-arg=GOIMPORTS_VERSION="$(GOIMPORTS_VERSION)"
+COMMON_ARGS += --build-arg=GOMOCK_VERSION="$(GOMOCK_VERSION)"
 COMMON_ARGS += --build-arg=DEEPCOPY_VERSION="$(DEEPCOPY_VERSION)"
 COMMON_ARGS += --build-arg=GOLANGCILINT_VERSION="$(GOLANGCILINT_VERSION)"
 COMMON_ARGS += --build-arg=GOFUMPT_VERSION="$(GOFUMPT_VERSION)"
 COMMON_ARGS += --build-arg=TESTPKGS="$(TESTPKGS)"
-TOOLCHAIN ?= docker.io/golang:1.24-alpine
+TOOLCHAIN ?= docker.io/golang:1.25-alpine
 
 # help menu
 
@@ -160,8 +163,14 @@ local-%:  ## Builds the specified target defined in the Dockerfile using the loc
 	    fi; \
 	  done'
 
+generate:  ## Generate .proto definitions.
+	@$(MAKE) local-$@ DEST=./
+
 lint-golangci-lint:  ## Runs golangci-lint linter.
 	@$(MAKE) target-$@
+
+lint-golangci-lint-fmt:  ## Runs golangci-lint formatter and tries to fix issues automatically.
+	@$(MAKE) local-$@ DEST=.
 
 lint-gofumpt:  ## Runs gofumpt linter.
 	@$(MAKE) target-$@

--- a/debug_on_124.go
+++ b/debug_on_124.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
-//go:build go1.24 && !go1.25
+//go:build go1.24 && !go1.26
 
 package debug
 

--- a/debug_on_125_test.go
+++ b/debug_on_125_test.go
@@ -1,0 +1,30 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+//go:build sidero.debug && go1.24 && !go1.26
+
+package debug //nolint:testpackage // to test unexported method
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDebugOn(t *testing.T) {
+	expected := []string{
+		"/debug/events",
+		"/debug/requests",
+		"GET /debug/pprof/",
+		"GET /debug/pprof/cmdline",
+		"GET /debug/pprof/profile",
+		"GET /debug/pprof/symbol",
+		"GET /debug/pprof/trace",
+		"GET /debug/vars",
+	}
+	assert.Equal(t, expected, handlers())
+
+	assert.Equal(t, 524288, runtime.MemProfileRate)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/siderolabs/go-debug
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	golang.org/x/net v0.35.0
+	golang.org/x/net v0.43.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/net v0.35.0 h1:T5GQRQb2y08kTAByq9L4/bz8cipCdA8FbRTXewonqY8=
-golang.org/x/net v0.35.0/go.mod h1:EglIi67kWsHKlRzzVMUD93VMSWGFOMSZgxFjparz1Qk=
+golang.org/x/net v0.43.0 h1:lat02VYK2j4aLzMzecihNvTlJNQUq316m2Mr9rnM6YE=
+golang.org/x/net v0.43.0/go.mod h1:vhO1fvI4dGsIjh73sWfUVjj3N7CA9WkKJNQm2svM6Jg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/hack/govulncheck.sh
+++ b/hack/govulncheck.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Source: https://github.com/tianon/gosu/blob/e157efb/govulncheck-with-excludes.sh
+# Licensed under the Apache License, Version 2.0
+# Copyright Tianon Gravi
+set -Eeuo pipefail
+
+exclude_arg=""
+pass_args=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -exclude)
+            exclude_arg="$2"
+            shift 2
+            ;;
+        *)
+            pass_args+=("$1")
+            shift
+            ;;
+    esac
+done
+
+if [[ -n "$exclude_arg" ]]; then
+    excludeVulns="$(jq -nc --arg list "$exclude_arg" '$list | split(",")')"
+else
+    excludeVulns="[]"
+fi
+
+export excludeVulns
+
+# Debug print
+echo "excludeVulns = $excludeVulns"
+echo "Passing args: ${pass_args[*]}"
+
+if ! command -v govulncheck > /dev/null; then
+    printf "govulncheck not installed"
+    exit 1
+fi
+
+if out="$(govulncheck "${pass_args[@]}")"; then
+	printf '%s\n' "$out"
+	exit 0
+fi
+
+json="$(govulncheck -json "${pass_args[@]}")"
+
+vulns="$(jq <<<"$json" -cs '
+	(
+		map(
+			.osv // empty
+			| { key: .id, value: . }
+		)
+		| from_entries
+	) as $meta
+	# https://github.com/tianon/gosu/issues/144
+	| map(
+		.finding // empty
+		# https://github.com/golang/vuln/blob/3740f5cb12a3f93b18dbe200c4bcb6256f8586e2/internal/scan/template.go#L97-L104
+		| select((.trace[0].function // "") != "")
+		| .osv
+	)
+	| unique
+	| map($meta[.])
+')"
+if [ "$(jq <<<"$vulns" -r 'length')" -le 0 ]; then
+	printf '%s\n' "$out"
+	exit 1
+fi
+
+filtered="$(jq <<<"$vulns" -c '
+	(env.excludeVulns | fromjson) as $exclude
+	| map(select(
+		.id as $id
+		| $exclude | index($id) | not
+	))
+')"
+
+text="$(jq <<<"$filtered" -r 'map("- \(.id) (aka \(.aliases | join(", ")))\n\n\t\(.details | gsub("\n"; "\n\t"))") | join("\n\n")')"
+
+if [ -z "$text" ]; then
+	printf 'No vulnerabilities found.\n'
+	exit 0
+else
+	printf '%s\n' "$text"
+	exit 1
+fi

--- a/internal/version/data/sha
+++ b/internal/version/data/sha
@@ -1,0 +1,1 @@
+undefined

--- a/internal/version/data/tag
+++ b/internal/version/data/tag
@@ -1,0 +1,1 @@
+undefined

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,41 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
+//
+// Generated on 2025-08-19T12:02:29Z by kres d1ef768.
+
+// Package version contains variables such as project name, tag and sha. It's a proper alternative to using
+// -ldflags '-X ...'.
+package version
+
+import (
+	_ "embed"
+	"runtime/debug"
+	"strings"
+)
+
+var (
+	// Tag declares project git tag.
+	//go:embed data/tag
+	Tag string
+	// SHA declares project git SHA.
+	//go:embed data/sha
+	SHA string
+	// Name declares project name.
+	Name = func() string {
+		info, ok := debug.ReadBuildInfo()
+		if !ok {
+			panic("cannot read build info, something is very wrong")
+		}
+
+		// Check if siderolabs project
+		if strings.HasPrefix(info.Path, "github.com/siderolabs/") {
+			return info.Path[strings.LastIndex(info.Path, "/")+1:]
+		}
+
+		// We could return a proper full path here, but it could be seen as a privacy violation.
+		return "community-project"
+	}()
+)


### PR DESCRIPTION
Run `rekres`, bump deps and change `handler` for Go 1.25.
